### PR TITLE
fix memory leak & add base unit tests

### DIFF
--- a/src/__tests__/chat.test.ts
+++ b/src/__tests__/chat.test.ts
@@ -1,0 +1,52 @@
+import { ConversationHistoryManager } from '../chat'
+
+describe('ConversationHistoryManager', () => {
+  let manager: ConversationHistoryManager
+
+  beforeEach(() => {
+    manager = new ConversationHistoryManager()
+  })
+
+  it('should start with empty history', () => {
+    const messages = manager.getMessages()
+    expect(messages).toEqual([])
+  })
+
+  it('should track new messages', () => {
+    const messages = [{ role: 'user', content: 'Hello' }]
+    const { newMessages, requiresReset } = manager.processNewMessages(messages)
+
+    expect(newMessages).toEqual(messages)
+    expect(requiresReset).toBe(false)
+  })
+
+  it('should detect divergent history', () => {
+    manager.update([{ role: 'user', content: 'Hello' }], { role: 'assistant', content: 'Hi' })
+
+    const differentMessages = [{ role: 'user', content: 'Different' }]
+    const { newMessages, requiresReset } = manager.processNewMessages(differentMessages)
+
+    expect(requiresReset).toBe(true)
+    expect(newMessages).toEqual(differentMessages)
+  })
+
+  it('should only return new messages on continuation', () => {
+    const msg1 = { role: 'user', content: 'Hello' }
+    const msg2 = { role: 'assistant', content: 'Hi' }
+    const msg3 = { role: 'user', content: 'How are you?' }
+
+    manager.update([msg1], msg2)
+    const { newMessages, requiresReset } = manager.processNewMessages([msg1, msg2, msg3])
+
+    expect(newMessages).toEqual([msg3])
+    expect(requiresReset).toBe(false)
+  })
+
+  it('should reset history on reset call', () => {
+    manager.update([{ role: 'user', content: 'Hello' }], { role: 'assistant', content: 'Hi' })
+    manager.reset()
+
+    const messages = manager.getMessages()
+    expect(messages).toEqual([])
+  })
+})

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,0 +1,53 @@
+import { Tools } from '../tools'
+
+describe('Tools', () => {
+  let tools: Tools
+
+  beforeEach(() => {
+    tools = new Tools()
+  })
+
+  it('should add and execute a tool', async () => {
+    function doubleNumber(x: number) { return x * 2 }
+    
+    tools.add(doubleNumber, 'Doubles a number', {
+      x: { type: 'number', description: 'Number to double', required: true }
+    })
+
+    const result = await tools.execute('doubleNumber', { x: 5 })
+    
+    expect(result).toBe(10)
+  })
+
+  it('should generate OpenAI schema', () => {
+    const weatherFn = (location: string) => `Weather in ${location}`
+    
+    tools.add(weatherFn, 'Get weather', {
+      location: { type: 'string', description: 'City name', required: true }
+    })
+
+    const schemas = tools.getSchemas()
+    
+    expect(schemas).toHaveLength(1)
+    expect(schemas[0]).toMatchObject({
+      type: 'function',
+      function: {
+        name: 'weatherFn',
+        description: 'Get weather',
+        parameters: {
+          type: 'object',
+          properties: {
+            location: { type: 'string', description: 'City name' }
+          },
+          required: ['location']
+        }
+      }
+    })
+  })
+
+  it('should throw error for non-existent tool', async () => {
+    await expect(
+      tools.execute('nonExistent', {})
+    ).rejects.toThrow('Tool nonExistent not found')
+  })
+})

--- a/src/lm.ts
+++ b/src/lm.ts
@@ -131,10 +131,12 @@ export class CactusLM {
 
     CactusLM._initCache.set(key, initPromise);
 
-    const result = await initPromise;
-    // Cache only while in-flight; never cache resolved instances
-    CactusLM._initCache.delete(key);
-    return result;
+    try {
+      const result = await initPromise;
+      return result;
+    } finally {
+      CactusLM._initCache.delete(key);
+    }
   }
 
   completion = async (

--- a/src/vlm.ts
+++ b/src/vlm.ts
@@ -118,11 +118,12 @@ export class CactusVLM {
 
     CactusVLM._initCache.set(key, initPromise);
 
-    const result = await initPromise;
-    if (result.error) {
-      CactusVLM._initCache.delete(key); 
+    try {
+      const result = await initPromise;
+      return result;
+    } finally {
+      CactusVLM._initCache.delete(key);
     }
-    return result;
   }
 
   async completion(


### PR DESCRIPTION
helloo, its mee
I fixed memory leak in `CactusLM` and `CactusVLM` where failed initialization attempts were never removed from cache, to be specific, I added `try-finally` blocks to ensure cache cleanup on both success and failure paths
- Prevents unbounded memory growth in long-running apps with repeated failed init attempts

also 
I added 8 unit tests covering core functionality, tests for `ConversationHistoryManager` 
- Tests for `Tools` class 
<img width="574" height="149" alt="Screenshot 2025-10-13 191151" src="https://github.com/user-attachments/assets/8e1d06b1-aa3a-4c24-9a9b-47589126930c" />
<img width="582" height="224" alt="Screenshot 2025-10-13 191236" src="https://github.com/user-attachments/assets/dd0f1f6d-664a-4889-8c35-7c9357ccd8f4" />
