### PR TITLE
fix: remove unnecessary react plugin to avoid duplicate class generation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,6 @@ apply plugin: "kotlin-android"
 apply from: '../nitrogen/generated/android/cactus+autolinking.gradle'
 
 
-
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["Cactus_" + name]).toInteger()
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply from: '../nitrogen/generated/android/cactus+autolinking.gradle'
 
-apply plugin: "com.facebook.react"
+
 
 def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["Cactus_" + name]).toInteger()


### PR DESCRIPTION
## Summary
- Remove `com.facebook.react` plugin to prevent duplicate class generation for TurboModules in the monorepo.
- The library uses Nitrogen for bindings, making the standard Codegen plugin unnecessary and conflicting.

## Motivation
The `com.facebook.react` plugin is primarily for apps. When applied to a library in a workspace, it scans dependencies and generates code for TurboModules (like `react-native-safe-area-context`). Since the example app also applies this plugin, it causes duplicate class errors (e.g., `RNCSafeAreaProviderManagerDelegate`). This library uses Nitrogen, so the standard plugin is not required.