### PR TITLE
feat: export CactusImage to make it available for consumers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 // Classes
 export { CactusLM } from './classes/CactusLM';
+export { CactusImage } from './native/CactusImage';
+
 
 // Hooks
 export { useCactusLM } from './hooks/useCactusLM';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,6 @@
 export { CactusLM } from './classes/CactusLM';
 export { CactusImage } from './native/CactusImage';
 
-
 // Hooks
 export { useCactusLM } from './hooks/useCactusLM';
 


### PR DESCRIPTION
## Summary
- Export `CactusImage` from `src/index.tsx`.

## Motivation
`CactusImage` was previously internal or not exposed via the main entry point. Exporting it allows the example app and other consumers of the library to import and use `CactusImage` directly.