### PR TITLE
fix: use dynamic ndkVersion in android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,7 @@ def getExtOrIntegerDefault(name) {
 android {
   namespace "com.margelo.nitro.cactus"
 
+  ndkVersion getExtOrDefault("ndkVersion")
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {


### PR DESCRIPTION
## Summary
- Update `android/build.gradle` to set `ndkVersion` dynamically using `getExtOrDefault("ndkVersion")`.

## Motivation
Instead of hardcoding the NDK version or relying on defaults, this change allows the `ndkVersion` to be defined in the root project or `gradle.properties`, ensuring consistency across the workspace and matching the environment configuration (e.g., `27.1.12297006`). This aligns with how other versions like `minSdkVersion` are handled.